### PR TITLE
Update to versioned scripts

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.194.0/containers/ubuntu
 {
     "name": "dev-c7",
-    "image": "ghcr.io/dls-controls/dev-c7",
+    "image": "ghcr.io/dls-controls/dev-c7:latest",
     "remoteEnv": {
         "DISPLAY": "${localEnv:DISPLAY}",
         "HOME": "${localEnv:HOME}"

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -66,3 +66,28 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+
+  release:
+    needs: [make-container]
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: make release scripts
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        run: |
+          # create version specific launcher and devcontainer
+          version=${GITHUB_REF#refs/*/}
+          sed  's/\(^ *"image".*\)\(latest\)/\1'"${version}"/ .devcontainer.json > /tmp/devcontainer.json
+          sed  's/\(version=.*\)\(latest\)/\1'"${version}"/ run-dev-c7.sh > /tmp/run-dev-c7.sh
+
+      - name: Github Release
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # v0.1.14
+        with:
+          files: |
+            /tmp/devcontainer.json
+            /tmp/run-dev-c7.sh
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/tutorials/start.rst
+++ b/docs/tutorials/start.rst
@@ -26,8 +26,12 @@ Startup Script run-dev-c7.sh
 Next, copy the startup script to your local bin directory and make it 
 executable::
 
-    curl https://raw.githubusercontent.com/dls-controls/dev-c7/main/run-dev-c7.sh -o $HOME/bin/run-dev-c7.sh
-    chmod +x $HOME/bin/run-dev-c7.sh
+    cd $HOME/bin
+    wget -q https://github.com/dls-controls/dev-c7/releases/download/2.0.0/run-dev-c7.sh
+    chmod run-dev-c7.sh
+
+The above gets version 2.0.0 which is current as of 01/07/2022.
+See https://github.com/dls-controls/dev-c7/releases for the latest updates.
 
 Finally, launch an instance of the container by typing::
 

--- a/docs/tutorials/vscode.rst
+++ b/docs/tutorials/vscode.rst
@@ -67,10 +67,13 @@ How to Use
 ----------
 
 To use VSCode with a developer container, first add the
-``.devcontainer.json`` file to the root of your project::
+``.devcontainer`` folder with ``devcontainer.json`` 
+file to the root of your project::
 
     cd <my project folder>
-    curl -O https://raw.githubusercontent.com/dls-controls/dev-c7/main/.devcontainer.json
+    mkdir .devcontainer
+    cd .devcontainer
+    wget -q https://github.com/dls-controls/dev-c7/releases/download/2.0.0/devcontainer.json
 
 Then launch VSCode::
 
@@ -85,6 +88,10 @@ Close the first terminal that you see and open another one (see `vscode_known`)
 
 That's it, you are now running a developer container and your vscode session
 is connected to it.
+
+The above gets version 2.0.0 which is current as of 01/07/2022.
+See https://github.com/dls-controls/dev-c7/releases for the latest updates.
+
 
 Container Lifetime
 ------------------
@@ -123,7 +130,7 @@ not be seen in the other.
       Folder to Workspace" from the right click menu in the File Explorer
     - choose ``File->Save Workspace As...`` and save the workspace to a 
       file, usually in the folder that is a common root to your projects.
-    - copy ``.devcontainer.json`` file to the same folder as the workspace
+    - copy the ``.devcontainer`` folder to the same folder as the workspace
       file.
     - go to the remotes menu (icon in bottom left of VSCode) and choose
       ``Reopen Container``

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pre-commit
 sphinx-rtd-theme-github-versions
-sphinx-rtd-theme-github-versions
 sphinx-apischema

--- a/run-dev-c7.sh
+++ b/run-dev-c7.sh
@@ -112,10 +112,10 @@ if [[ -n $(podman ps -q -f name=${container_name}) ]]; then
         echo "Delete the container with 'podman rm -ft0 dev-c7' and retry."
         exit 1
     fi 
-    echo 'attaching to exisitng dev-c7 container ...'
+    echo 'attaching to exisitng dev-c7 container ${version} ...'
 elif [[ -n $(podman ps -qa -f name=${container_name}) ]]; then
     # start the stopped container
-    echo 'restarting stopped dev-c7 container ...'
+    echo 'restarting stopped dev-c7 container ${version} ...'
     podman start ${container_name}
 else
     # check for updates if requested
@@ -127,7 +127,7 @@ else
     # prior to sleep we update the default shell to be bash
     # this is because podman adds a user in etc/passwd but fails to honor
     # /etc/adduser.conf
-    echo 'creating new dev-c7 container ...'
+    echo 'creating new dev-c7 container ${version} ...'
     podman run -dit --name ${container_name} ${runtime} ${environ}\
         ${identity} ${volumes} ${devices} ${opts} ${image}:${version} \
         bash -c "sudo sed -i s#/bin/sh#/bin/bash# /etc/passwd ; bash"


### PR DESCRIPTION
- scripts now use specific version of the container
- run-dev-c7 announces the version
- versioned scripts are published as release assets
- the docs point to the released assets
