### PR TITLE
Add /dls/technical to list of automount

### DIFF
--- a/c7
+++ b/c7
@@ -99,6 +99,7 @@ shift $((OPTIND-1))
 automounts="
     /dls_sw/prod /dls_sw/work /dls_sw/epics /dls_sw/targetOS /dls_sw/apps
     /dls_sw/etc /dls_sw/optics /dls_sw/FPGA/ /dls/science /dls/detectors
+    /dls/technical
 "
 for mount in ${automounts} ; do
     ls -d ${mount} &> /dev/null


### PR DESCRIPTION
dls_ade needs to read from /dls/technical/controls so ensure it is mountable as a volume by adding it to the list of automounts.