### PR TITLE
Use shared property for automounts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,9 +32,9 @@
         "for mount in /dls_sw/prod /dls_sw/work /dls_sw/epics /dls_sw/targetOS /dls_sw/apps /dls_sw/etc /dls_sw/optics /dls_sw/FPGA/ /dls/science /dls/detectors ; do ls -d ${mount} &> /dev/null ; done"
     ],
     "mounts": [
-        "source=/dls,target=/dls,type=bind,consistency=cached",
-        "source=/dls_sw,target=/dls_sw,type=bind,consistency=cached",
-        "source=/home,target=/home,type=bind,consistency=cached",
+        "source=/dls,target=/dls,type=bind,consistency=cached,bind-propagation=shared",
+        "source=/dls_sw,target=/dls_sw,type=bind,consistency=cached,bind-propagation=shared",
+        "source=/home,target=/home,type=bind,consistency=cached,bind-propagation=shared",
         "source=/scratch/,target=/scratch/,type=bind,consistency=cached",
         "source=/tmp,target=/tmp,type=bind,consistency=cached",
         "source=${localEnv:SSH_AUTH_SOCK},target=${localEnv:SSH_AUTH_SOCK},type=bind,consistency=cached"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,14 +23,6 @@
         "redhat.vscode-yaml",
         "nsd.vscode-epics"
     ],
-    // automount fails inside a container so make sure any automounts that are
-    // needed get mounted before launching the container.
-    // NOTE: Add any personal / beamline specific automounts here
-    "initializeCommand": [
-        "bash",
-        "-c",
-        "for mount in /dls_sw/prod /dls_sw/work /dls_sw/epics /dls_sw/targetOS /dls_sw/apps /dls_sw/etc /dls_sw/optics /dls_sw/FPGA/ /dls/science /dls/detectors ; do ls -d ${mount} &> /dev/null ; done"
-    ],
     "mounts": [
         "source=/dls,target=/dls,type=bind,consistency=cached,bind-propagation=shared",
         "source=/dls_sw,target=/dls_sw,type=bind,consistency=cached,bind-propagation=shared",

--- a/c7
+++ b/c7
@@ -60,8 +60,6 @@ while getopts "mglrdphs:i:v:cnI" arg; do
         ;;
     d)  delete=true
         ;;
-    m)  mount_only=true
-        ;;
     I)  install_devcontainer_json=true
         ;;
     *)
@@ -84,7 +82,6 @@ Options:
     -I              Install .devcontainer/devcontainer.json in the current directory for vscode
     -g              enable X11 GUI for containers launched via ssh (only required with -r)
     -r              run as root
-    -m              dont run the container. Just mount the automount filesystems
 "
         exit 0
         ;;
@@ -92,22 +89,6 @@ Options:
 done
 
 shift $((OPTIND-1))
-
-# automount fails inside a container so make sure any automounts that are
-# needed get mounted before launching the container.
-# NOTE: Add any personal / beamline specific automounts here
-automounts="
-    /dls_sw/prod /dls_sw/work /dls_sw/epics /dls_sw/targetOS /dls_sw/apps
-    /dls_sw/etc /dls_sw/optics /dls_sw/FPGA/ /dls/science /dls/detectors
-    /dls/technical
-"
-for mount in ${automounts} ; do
-    ls -d ${mount} &> /dev/null
-done
-
-if ${mount_only} ; then
-    exit 0
-fi
 
 if [[ ${install_devcontainer_json} == true ]] ; then
     mkdir -p .devcontainer
@@ -146,9 +127,9 @@ fi
 environ="-e DISPLAY -e HOME -e USER -e SSH_AUTH_SOCK"
 volumes="
     -v /scratch:/scratch
-    -v /dls:/dls
-    -v /dls_sw:/dls_sw
-    -v /home:/home
+    -v /dls:/dls:shared
+    -v /dls_sw:/dls_sw:shared
+    -v /home:/home:shared
     -v /run/user/$(id -u):/run/user/$(id -u)
 "
 


### PR DESCRIPTION
I found that the existing method wasn't working for me - I kept getting the "too many levels of symbolic links" error from the automounted directories. This is a proposal for an alternative method that seems to work for me.

See `man podman-run`, search for `bind-propagation`, for what it is doing. I think it is okay to make the container mounts visible on the host since they are alaready visible where mounted on the host. Is this a correct assumption?