### PR TITLE
Add container name to env vars

### DIFF
--- a/c7
+++ b/c7
@@ -124,7 +124,16 @@ use group permissions
     rhel=7
 fi
 
-environ="-e DISPLAY -e HOME -e USER -e SSH_AUTH_SOCK"
+environ="
+    -e CONTAINER_NAME=dev-c7
+    -e DEV_PROMPT=C7
+    -e DISPLAY
+    -e HOME
+    -e USER
+    -e SSH_AUTH_SOCK
+    -e TERM=xterm-256color
+"
+
 volumes="
     -v /scratch:/scratch
     -v /dls:/dls:shared
@@ -224,8 +233,8 @@ fi
 # using process 1 so users can exit the shell without killing the container
 if [[ -n ${commandargs} ]] ; then
     ${logging}
-    podman exec -itw $(pwd) ${container_name} env TERM=xterm-256color ${command} "$*"
+    podman exec -itw $(pwd) ${container_name} ${command} "$*"
 else
     ${logging}
-    podman exec -itw $(pwd) ${container_name} env TERM=xterm-256color ${command}
+    podman exec -itw $(pwd) ${container_name} ${command}
 fi


### PR DESCRIPTION
Moved all environment variables into a new `env.list` file, and edited build to use this env var list instead of a string of env vars.