### PR TITLE
fix issue with git permissions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,3 +62,6 @@ RUN yum remove -y git git-* && \
 # change the nobody account and group IDs to match RedHat
 RUN sed -i 's/99:99/65534:65534/' /etc/passwd && \
     sed -i 's/:99:/:65534:/' /etc/group
+
+# Remove the git ownership check because this matches the behaviour of RHEL7 git
+RUN git config --global --add safe.directory '*'


### PR DESCRIPTION
This removes the ownership check for all git repos. 

Given that the version of git we have in RHEL7 does not do this check, this is consistent with RHEL7 boxes.